### PR TITLE
D8/9 - Fix checkbox field to be disabled on the setting page.

### DIFF
--- a/CRM/Cmsuser/Form/Setting.php
+++ b/CRM/Cmsuser/Form/Setting.php
@@ -13,8 +13,8 @@ class CRM_Cmsuser_Form_Setting extends CRM_Core_Form {
     // add form elements
 
     $this->add('text', 'cmsuser_pattern', 'Username pattern', ['size' => 60], TRUE);
-    $this->addElement('checkbox', 'cmsuser_notify', ts('Notify User?'));
-    $this->addElement('checkbox', 'cmsuser_create_immediately', ts('Create New User Immediately?'));
+    $this->add('advcheckbox', 'cmsuser_notify', ts('Notify User?'));
+    $this->add('advcheckbox', 'cmsuser_create_immediately', ts('Create New User Immediately?'));
     if (CIVICRM_UF == 'Drupal8') {
       $user_role_names = user_role_names();
       $this->add('select', 'cmsuser_cms_roles', ts('Assign Role to Users'),


### PR DESCRIPTION
Bug fix: User cannot disable `Notify User?` and other checkboxes on the settings form.