### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/Cmsuser/Create.php
+++ b/api/v3/Cmsuser/Create.php
@@ -46,7 +46,7 @@ function _civicrm_api3_cmsuser_Create_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_cmsuser_Create($params) {
   civicrm_api3_verify_mandatory($params, NULL, ['cms_name', 'email']);
@@ -58,7 +58,7 @@ function civicrm_api3_cmsuser_Create($params) {
 
       return civicrm_api3_create_error('CMS user account already exists for this contact.', $user);
     }
-    catch (CiviCRM_API3_Exception $e) {
+    catch (CRM_Core_Exception $e) {
       // user account doesn't exist, just fall through to rest of code
     }
   }

--- a/api/v3/Cmsuser/Reset.php
+++ b/api/v3/Cmsuser/Reset.php
@@ -23,7 +23,7 @@ function _civicrm_api3_cmsuser_Reset_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_cmsuser_Reset($params) {
   civicrm_api3_verify_mandatory($params, NULL, ['uf_id']);

--- a/api/v3/Job/Cmsuser.php
+++ b/api/v3/Job/Cmsuser.php
@@ -22,7 +22,7 @@ function _civicrm_api3_job_Cmsuser_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_job_Cmsuser($params) {
   $domainID = CRM_Core_Config::domainID();
@@ -183,7 +183,7 @@ function _cms_user_create($setDefaults, $isGroup = TRUE,
               'return' => 'email',
             ]);
           }
-          catch (CiviCRM_API3_Exception $e) {
+          catch (CRM_Core_Exception $e) {
             $api = [
               'is_error' => 1,
               'error_message' => $e->getMessage(),
@@ -245,7 +245,7 @@ function _cms_user_create($setDefaults, $isGroup = TRUE,
             ];
           }
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           $api = [
             'is_error' => 1,
             'error_message' => $e->getMessage(),
@@ -284,7 +284,7 @@ function _cms_user_create($setDefaults, $isGroup = TRUE,
             ]);
           }
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
         }
       }
 
@@ -339,7 +339,7 @@ function _cms_user_create($setDefaults, $isGroup = TRUE,
           }
         }
       }
-      catch (CiviCRM_API3_Exception $exception) {
+      catch (CRM_Core_Exception $exception) {
         CRM_Core_Error::debug_var('exception', $exception->getMessage());
       }
     }
@@ -411,7 +411,7 @@ function _cms_user_reset($setDefaults, $isGroup = TRUE) {
         // call our custom api to reset user
         $api = civicrm_api3('Cmsuser', 'Reset', $resetParams);
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $api = [
           'is_error' => 1,
           'error_message' => $e->getMessage(),
@@ -433,7 +433,7 @@ function _cms_user_reset($setDefaults, $isGroup = TRUE) {
             ]);
           }
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
         }
       }
 
@@ -461,7 +461,7 @@ function _cms_user_reset($setDefaults, $isGroup = TRUE) {
           'details' => $activityDetails,
         ]);
       }
-      catch (CiviCRM_API3_Exception $exception) {
+      catch (CRM_Core_Exception $exception) {
 
       }
     }


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.