### PR TITLE
Ensure group selectors render correctly

### DIFF
--- a/CRM/Cmsuser/Form/Setting.php
+++ b/CRM/Cmsuser/Form/Setting.php
@@ -105,7 +105,7 @@ class CRM_Cmsuser_Form_Setting extends CRM_Core_Form {
         $groupList, FALSE, ['class' => 'crm-select2 huge', 'multiple' => 1]);
     }
 
-    $groups = ['' => '-- select --'] + CRM_Core_PseudoConstant::nestedGroup();
+    $groups = ['' => '-- select --'] + CRM_Core_PseudoConstant::nestedGroup(TRUE, NULL, TRUE, "plain");
     $tags = ['' => '-- select --'] + CRM_Core_PseudoConstant::get('CRM_Core_DAO_EntityTag', 'tag_id', ['onlyActive' => FALSE]);
 
     $this->add('select', 'cmsuser_group_create', ts('Create CMS User for Group contact'), $groups);


### PR DESCRIPTION
In 6.13 select dropdowns always escape html which causes group selectors to look bad.
This passes the new to param to format the group hierarchy in a plain text compatible format.

This change is backward-compatible; in CiviCRM < 6.13 the new param will be ignored.