### PR TITLE
Fixing parameter name

### DIFF
--- a/api/v3/Cmsuser/Create.php
+++ b/api/v3/Cmsuser/Create.php
@@ -9,7 +9,7 @@ use CRM_Cmsuser_ExtensionUtil as E;
  *
  * @see https://docs.civicrm.org/dev/en/latest/framework/api-architecture/
  */
-function _civicrm_api3_cmsuser_Create_spec(&$spec) {
+function _civicrm_api3_cmsuser_Create_spec(&params) {
   $params['cms_name'] = [
     'api.required' => 1,
     'title' => 'CMS Username',


### PR DESCRIPTION
# Description

The parameter being passed was set to `spec` but you are modifying `params` so it was causing a lot of log errors and not function properly.